### PR TITLE
Fix welcome text box (overflow issues on smaller screens)

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,8 +136,6 @@ function initComparisons() {
     <i class="fa fa-phone"      style="width:30px"> </i>+1 202 9949265<br>
     <i class="fa fa-map-marker" style="width:30px"> </i>Corcoran Hall, 725 21st NW, Washington, DC</p>
     </div>
-<br><br><br><br><br>
-<br><br><br><br><br><br><br><br>
 </div>
 
 <hr><!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->

--- a/stylesheets/main.css
+++ b/stylesheets/main.css
@@ -43,11 +43,6 @@
 
 /* %%%%%%%%%%%%%%%%%%%%%% header %%%%%%%%%%%%%%%%%%%%%% */
 .content {
-  position: absolute; /* Position the background text */
-  right: 0px;
-  top: 250px;
-  bottom: 0px; /* At the bottom. Use top:0 to append it to the top */
-  background: rgb(0, 0, 0); /* Fallback color */
   background: rgba(999, 999, 999, 0.8); /* Black background with 0.5 opacity */
   color: rgba(0,0,0, 0.9); /* Grey text */
   width: 100%; /* Full width */


### PR DESCRIPTION
Hey Maxim,

ich bin mir nicht sicher ob ich das Problem verstanden habe. Für kleinere Screens sieht das mit diesem Fix jetzt so aus (der Text ist **unter** dem Bild statt **auf dem Bild**):

![image](https://user-images.githubusercontent.com/3519464/80115529-2409fb80-8585-11ea-8345-5c69aa73a97d.png)

Passt das?
