### PR TITLE
Fix horizontal scrolling on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,10 +196,10 @@ Lattice computations are necessarily performed on discretized Eucledean space ti
 
   <div class="img-comp-container">
     <div class="img-comp-img">
-      <img src="content/INFVOL.jpg" width="400" height="240">
+      <img src="content/INFVOL.jpg" class="chart-img">
     </div>
     <div class="img-comp-img img-comp-overlay">
-      <img src="content/FINVOL.jpg" width="400" height="240">
+      <img src="content/FINVOL.jpg" class="chart-img">
     </div>
   </div>
 

--- a/stylesheets/main.css
+++ b/stylesheets/main.css
@@ -37,6 +37,17 @@
   opacity: 0.8;
   border-radius: 1%;
 }
+
+.chart-img {
+  width: 330px;
+}
+
+@media (min-width:601px){
+  .chart-img {
+    width: 400px;
+  }
+}
+
 /* %%%%%%%%%%%%%%%%%%%%%% END SLIDER %%%%%%%%%%%%%%%%%%%%%% */
 
 


### PR DESCRIPTION
Auf Smartphones hatte die Seite horizontales Scrolling (siehe Screenshot). Der Pull-Request fixt das. 

![image](https://user-images.githubusercontent.com/3519464/80118171-5406ce00-8588-11ea-9a0c-1885ee431c55.png)

